### PR TITLE
Change in versions for releasing CiviCRM extension

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,6 @@
   <version>v1.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.1</ver>
     <ver>5.2</ver>
   </compatibility>
   <civix>

--- a/info.xml
+++ b/info.xml
@@ -1,4 +1,4 @@
-<?xml version="v1.0"?>
+<?xml version="1.0"?>
 <extension key="io.callhub.phonebanking" type="module">
   <file>phonebanking</file>
   <name>CallHub Phone Banking</name>

--- a/info.xml
+++ b/info.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="v1.0"?>
 <extension key="io.callhub.phonebanking" type="module">
   <file>phonebanking</file>
   <name>CallHub Phone Banking</name>
@@ -15,11 +15,11 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2017-03-31</releaseDate>
-  <version>1.0</version>
+  <version>v1.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.6</ver>
-    <ver>4.7</ver>
+    <ver>5.1</ver>
+    <ver>5.2</ver>
   </compatibility>
   <civix>
     <namespace>CRM/Phonebanking</namespace>


### PR DESCRIPTION
- Read the guidelines at https://docs.civicrm.org/dev/en/latest/extensions/info-xml/ and made the changes
- compatibility of 5.2 will make our extension listed on 5.3 and beyond (CiviCRM 5.2 was tested today with bitnami image)
- version of the extension is changed to v1.0 to match the git tag